### PR TITLE
29 generate localize csv file

### DIFF
--- a/assets/translations/langs.csv
+++ b/assets/translations/langs.csv
@@ -1,10 +1,11 @@
 str,en,km
+choose_a_language,Choose a language,ជ្រើសភាសា
 completed_orders,Completed orders,ការបញ្ជាទិញបានបញ្ចប់
-connect_sorrounding_store,Connect sorrounding store,ហាងភ្ជាប់ sorrounding
 continue,Continue,បន្ត
 continue,Continue,បន្ត
-continue_with_email,Continue with email,បន្តជាមួយអ៊ីម៉ែល
 continue_with_mobile_phone,Continue with mobile phone,បន្តជាមួយទូរស័ព្ទដៃ
+continue_with_email,Continue with email,បន្តជាមួយអ៊ីម៉ែល
+connect_sorrounding_store,Connect sorrounding store,ហាងភ្ជាប់ sorrounding
 email,Email,អ៊ីម៉ែល
 enter_your_email_address,Enter your email address,សូម​ប​ញ្ជូ​ល​អាសយដ្ឋាន​អ៊ី​ម៊ែ​ល​របស់​អ្នក
 enter_your_password,Enter your password,បញ្ចូលពាក្យសម្ងាត់របស់អ្នក
@@ -38,4 +39,3 @@ welcome_to_vtenh,Welcome to VTenh,សូមស្វាគមន៍មកកា�
 you_can_push_the_button_this_many_times,You can push the button this many times,អ្នកអាចជំរុញឱ្យមានប៊ូតុងច្រើនដងនេះ
 you_changed_your_language_to,You changed your language to,អ្នកបានផ្លាស់ប្តូរទៅជាភាសារបស់អ្នក
 your_order_shipped_and_we_give_your_tracking_code_and_get_notified,Your order shipped and we give your tracking code and get notified,ការបញ្ជាទិញរបស់អ្នកបាននាំចេញហើយយើងផ្ដល់កូដតាមដានរបស់អ្នកនិងទទួលបានការជូនដំណឹង
-choose_a_language,Choose a language,ជ្រើសភាសា

--- a/darts/langs.dart
+++ b/darts/langs.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:vtenhappmerchant/constants/api_constant.dart';
+
+/// Before generate new `lang.csv` file, please make sure that:
+/// - `VTenh Merchant App Translation - langs` is published in Google Spreadsheets
+/// - there is no space or empty row and it is sorted
+
+/// To generate `lang.csv`,
+///
+/// Run following command in terminal:
+/// ```
+/// dart run darts/langs.dart
+/// ```
+void main() async {
+  Dio dio = Dio();
+  Response<dynamic> response;
+  String endpoint = ApiConstant.localizeEndPoint;
+  response = await dio.get(endpoint);
+
+  File file = File("assets/translations/langs.csv");
+  file.openWrite();
+  file.writeAsString(response.toString());
+}

--- a/lib/constants/api_constant.dart.example
+++ b/lib/constants/api_constant.dart.example
@@ -14,5 +14,8 @@ class ApiConstant {
   static final String clientId = '';
   static final String clientSecret = '';
 
+  static final String localizeEndPoint =
+    "https://docs.google.com/spreadsheets/d/e/2PACX-1vRfC4yLNMc6p96WVQpCwAxnq3s2Va-tvee2yaA9YTl4c5TaGOfx_iGxWjeYIzdMmKGRSqXSI6pewAq0/pub?gid=1286847532&single=true&output=csv";
+
   static final int recordPerPage = 10;
 }


### PR DESCRIPTION
  Before generate new `lang.csv` file, please make sure that:
  - `VTenh Merchant App Translation - langs` is published in Google Spreadsheets
  - There is no space or empty row and it is sorted

  To generate `lang.csv`, 
  1. Use this published endpoint 
```
static final String localizeEndPoint =
     "https://docs.google.com/spreadsheets/d/e/2PACX-1vRfC4yLNMc6p96WVQpCwAxnq3s2Va-tvee2yaA9YTl4c5TaGOfx_iGxWjeYIzdMmKGRSqXSI6pewAq0/pub?gid=1286847532&single=true&output=csv";
```

  2. Run following command in terminal:
```
dart run darts/langs.dart
```